### PR TITLE
Fixed compatibility with mw 1.23.1

### DIFF
--- a/AccessControl.php
+++ b/AccessControl.php
@@ -206,6 +206,7 @@ function fromTemplates( $string ) {
 		    $end = strpos( $string, '}}' );
 		    $skok = $start + 2;
 		    $templatepage = substr( $string, $skok, $end - $skok );
+		    $rights = '';
 		    if ( substr( $templatepage, 0, 1 ) == '{' ) {
 				// The check of included code
 				$rights = fromTemplates( $templatepage );


### PR DESCRIPTION
With the latest mediawiki, your extension was causing a warning due to using the variable $rights on line 226 before it was declared. Added declaration $rights variable.
