### PR TITLE
Fix: Resolve TypeError on User object array offsets for MW 1.45+

### DIFF
--- a/src/AccessControlHooks.php
+++ b/src/AccessControlHooks.php
@@ -832,9 +832,9 @@ class AccessControlHooks {
 										/* Nemá smysl zjišťovat všechny skupiny. Stačí zjistit, jestli do ní patří aktuální uživatel a přidat ho
 										*/
 										if ( $item[1] ) {
-											$allow[EDIT][ $user ] = true;
+											$allow[EDIT][ $user->getName() ] = true;
 										} else {
-											$allow[VIEW][ $user ] = true;
+											$allow[VIEW][ $user->getName() ] = true;
 										}
 									}
 								}
@@ -844,9 +844,9 @@ class AccessControlHooks {
 						if ( $item[0] === $user ) {
 							/* Username */
 							if ( $item[1] ) {
-								$allow[EDIT][ $user ] = true;
+								$allow[EDIT][ $user->getName() ] = true;
 							} else {
-								$allow[VIEW][ $user ] = true;
+								$allow[VIEW][ $user->getName() ] = true;
 							}
 						}
 						if ( $item[1] ) {
@@ -858,19 +858,19 @@ class AccessControlHooks {
 						if ( array_key_exists( EDIT, $array ) ) {
 							if ( $item[1] ) {
 								foreach ( array_keys( $array[EDIT] ) as $user ) {
-									$allow[EDIT][ $user ] = true;
+									$allow[EDIT][ $user->getName() ] = true;
 								}
 							} else {
 								/* (ro) */
 								foreach ( array_keys( $array[EDIT] ) as $user ) {
-									$allow[EDIT][ $user ] = false;
-									$allow[VIEW][ $user ] = true;
+									$allow[EDIT][ $user->getName() ] = false;
+									$allow[VIEW][ $user->getName() ] = true;
 								}
 							}
 						}
 						if ( array_key_exists( VIEW, $array ) ) {
 							foreach ( array_keys( $array[VIEW] ) as $user ) {
-								$allow[VIEW][ $user ] = true;
+								$allow[VIEW][ $user->getName() ] = true;
 							}
 						}
 					}


### PR DESCRIPTION
MediaWiki 1.45.1+ passes User objects to hooks. This change converts $user objects to strings via getName() when used as array keys to prevent "TypeError: Cannot access offset of type MediaWiki\User\User". 

Thus re-enabling 'bureaucrat', 'sysop', and other MediaWiki group recognition within <accesscontrol> tags.

Example: <accesscontrol>bureaucrat,sysop,customgroup</accesscontrol>